### PR TITLE
Ensure bit 20 in ARM table is correct

### DIFF
--- a/gba-doc/CPU/arm-table.html
+++ b/gba-doc/CPU/arm-table.html
@@ -380,165 +380,165 @@ td {
     </tr>
     <tr><td rowspan=32>20:27</td><td>00100000</td><td colspan=16>ANDI</td></tr>
     <tr><td>00100001</td><td colspan=16>ANDSI</td></tr>
-    <tr><td>00100011</td><td colspan=16>EORI</td></tr>
+    <tr><td>00100010</td><td colspan=16>EORI</td></tr>
     <tr><td>00100011</td><td colspan=16>EORSI</td></tr>
     <tr><td>00100100</td><td colspan=16>SUBI</td></tr>
     <tr><td>00100101</td><td colspan=16>SUBSI</td></tr>
-    <tr><td>00100111</td><td colspan=16>RSBI</td></tr>
+    <tr><td>00100110</td><td colspan=16>RSBI</td></tr>
     <tr><td>00100111</td><td colspan=16>RSBSI</td></tr>
     <tr><td>00101000</td><td colspan=16>ADDI</td></tr>
     <tr><td>00101001</td><td colspan=16>ADDSI</td></tr>
-    <tr><td>00101011</td><td colspan=16>ADCI</td></tr>
+    <tr><td>00101010</td><td colspan=16>ADCI</td></tr>
     <tr><td>00101011</td><td colspan=16>ADCSI</td></tr>
     <tr><td>00101100</td><td colspan=16>SBCI</td></tr>
     <tr><td>00101101</td><td colspan=16>SBCSI</td></tr>
-    <tr><td>00101111</td><td colspan=16>RSCI</td></tr>
+    <tr><td>00101110</td><td colspan=16>RSCI</td></tr>
     <tr><td>00101111</td><td colspan=16>RSCSI</td></tr>
     <tr><td>00110000</td><td colspan=16>TSTI</td></tr>
     <tr><td>00110001</td><td colspan=16>TSTI</td></tr>
-    <tr><td>00110011</td><td colspan=16>MSRI</td></tr>
+    <tr><td>00110010</td><td colspan=16>MSRI</td></tr>
     <tr><td>00110011</td><td colspan=16>TEQSI</td></tr>
     <tr><td>00110100</td><td colspan=16>CMPI</td></tr>
     <tr><td>00110101</td><td colspan=16>CMPI</td></tr>
-    <tr><td>00110111</td><td colspan=16>MSRR</td></tr>
+    <tr><td>00110110</td><td colspan=16>MSRR</td></tr>
     <tr><td>00110111</td><td colspan=16>CMNI</td></tr>
     <tr><td>00111000</td><td colspan=16>ORRI</td></tr>
     <tr><td>00111001</td><td colspan=16>ORRSI</td></tr>
-    <tr><td>00111011</td><td colspan=16>MOVI</td></tr>
+    <tr><td>00111010</td><td colspan=16>MOVI</td></tr>
     <tr><td>00111011</td><td colspan=16>MOVSI</td></tr>
     <tr><td>00111100</td><td colspan=16>BICI</td></tr>
     <tr><td>00111101</td><td colspan=16>BICSI</td></tr>
-    <tr><td>00111111</td><td colspan=16>MVNI</td></tr>
+    <tr><td>00111110</td><td colspan=16>MVNI</td></tr>
     <tr><td>00111111</td><td colspan=16>MVNSI</td></tr>
     <tr><td rowspan=32>20:27</td><td>01000000</td><td colspan=16>STRI</td></tr>
     <tr><td>01000001</td><td colspan=16>LDRI</td></tr>
-    <tr><td>01000011</td><td colspan=16>STRTI</td></tr>
+    <tr><td>01000010</td><td colspan=16>STRTI</td></tr>
     <tr><td>01000011</td><td colspan=16>LDRTI</td></tr>
     <tr><td>01000100</td><td colspan=16>STRBI</td></tr>
     <tr><td>01000101</td><td colspan=16>LDRBI</td></tr>
-    <tr><td>01000111</td><td colspan=16>STRBTI</td></tr>
+    <tr><td>01000110</td><td colspan=16>STRBTI</td></tr>
     <tr><td>01000111</td><td colspan=16>LDRBTI</td></tr>
     <tr><td>01001000</td><td colspan=16>STRI</td></tr>
     <tr><td>01001001</td><td colspan=16>LDRI</td></tr>
-    <tr><td>01001011</td><td colspan=16>STRTI</td></tr>
+    <tr><td>01001010</td><td colspan=16>STRTI</td></tr>
     <tr><td>01001011</td><td colspan=16>LDRTI</td></tr>
     <tr><td>01001100</td><td colspan=16>STRBI</td></tr>
     <tr><td>01001101</td><td colspan=16>LDRBI</td></tr>
-    <tr><td>01001111</td><td colspan=16>STRBTI</td></tr>
+    <tr><td>01001110</td><td colspan=16>STRBTI</td></tr>
     <tr><td>01001111</td><td colspan=16>LDRBTI</td></tr>
     <tr><td>01010000</td><td colspan=16>STRPI</td></tr>
     <tr><td>01010001</td><td colspan=16>LDRPI</td></tr>
-    <tr><td>01010011</td><td colspan=16>STRPI</td></tr>
+    <tr><td>01010010</td><td colspan=16>STRPI</td></tr>
     <tr><td>01010011</td><td colspan=16>LDRPI</td></tr>
     <tr><td>01010100</td><td colspan=16>STRBPI</td></tr>
     <tr><td>01010101</td><td colspan=16>LDRBPI</td></tr>
-    <tr><td>01010111</td><td colspan=16>STRBPI</td></tr>
+    <tr><td>01010110</td><td colspan=16>STRBPI</td></tr>
     <tr><td>01010111</td><td colspan=16>LDRBPI</td></tr>
     <tr><td>01011000</td><td colspan=16>STRPUI</td></tr>
     <tr><td>01011001</td><td colspan=16>LDRPUI</td></tr>
-    <tr><td>01011011</td><td colspan=16>STRPUWI</td></tr>
+    <tr><td>01011010</td><td colspan=16>STRPUWI</td></tr>
     <tr><td>01011011</td><td colspan=16>LDRPUWI</td></tr>
     <tr><td>01011100</td><td colspan=16>STRBPUI</td></tr>
     <tr><td>01011101</td><td colspan=16>LDRBPUI</td></tr>
-    <tr><td>01011111</td><td colspan=16>STRBPUWI</td></tr>
+    <tr><td>01011110</td><td colspan=16>STRBPUWI</td></tr>
     <tr><td>01011111</td><td colspan=16>LDRBPUWI</td></tr>
     <tr><td rowspan=32>20:27</td><td>01100000</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td></tr>
     <tr><td>01100001</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td></tr>
-    <tr><td>01100011</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td></tr>
+    <tr><td>01100010</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td></tr>
     <tr><td>01100011</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td></tr>
     <tr><td>01100100</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td></tr>
     <tr><td>01100101</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td></tr>
-    <tr><td>01100111</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td></tr>
+    <tr><td>01100110</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td></tr>
     <tr><td>01100111</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td></tr>
     <tr><td>01101000</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td><td>STR</td><td>-</td></tr>
     <tr><td>01101001</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td><td>LDR</td><td>-</td></tr>
-    <tr><td>01101011</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td></tr>
+    <tr><td>01101010</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td><td>STRT</td><td>-</td></tr>
     <tr><td>01101011</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td><td>LDRT</td><td>-</td></tr>
     <tr><td>01101100</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td><td>STRB</td><td>-</td></tr>
     <tr><td>01101101</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td><td>LDRB</td><td>-</td></tr>
-    <tr><td>01101111</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td></tr>
+    <tr><td>01101110</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td><td>STRBT</td><td>-</td></tr>
     <tr><td>01101111</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td><td>LDRBT</td><td>-</td></tr>
     <tr><td>01110000</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td></tr>
     <tr><td>01110001</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td></tr>
-    <tr><td>01110011</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td></tr>
+    <tr><td>01110010</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td><td>STRP</td><td>-</td></tr>
     <tr><td>01110011</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td><td>LDRP</td><td>-</td></tr>
     <tr><td>01110100</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td></tr>
     <tr><td>01110101</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td></tr>
-    <tr><td>01110111</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td></tr>
+    <tr><td>01110110</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td><td>STRBP</td><td>-</td></tr>
     <tr><td>01110111</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td><td>LDRBP</td><td>-</td></tr>
     <tr><td>01111000</td><td>STRPU</td><td>-</td><td>STRPU</td><td>-</td><td>STRPU</td><td>-</td><td>STRPU</td><td>-</td><td>STRPU</td><td>-</td><td>STRPU</td><td>-</td><td>STRPU</td><td>-</td><td>STRPU</td><td>-</td></tr>
     <tr><td>01111001</td><td>LDRPU</td><td>-</td><td>LDRPU</td><td>-</td><td>LDRPU</td><td>-</td><td>LDRPU</td><td>-</td><td>LDRPU</td><td>-</td><td>LDRPU</td><td>-</td><td>LDRPU</td><td>-</td><td>LDRPU</td><td>-</td></tr>
-    <tr><td>01111011</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td></tr>
+    <tr><td>01111010</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td><td>STRPUW</td><td>-</td></tr>
     <tr><td>01111011</td><td>LDRPUW</td><td>-</td><td>LDRPUW</td><td>-</td><td>LDRPUW</td><td>-</td><td>LDRPUW</td><td>-</td><td>LDRPUW</td><td>-</td><td>LDRPUW</td><td>-</td><td>LDRPUW</td><td>-</td><td>LDRPUW</td><td>-</td></tr>
     <tr><td>01111100</td><td>STRBPU</td><td>-</td><td>STRBPU</td><td>-</td><td>STRBPU</td><td>-</td><td>STRBPU</td><td>-</td><td>STRBPU</td><td>-</td><td>STRBPU</td><td>-</td><td>STRBPU</td><td>-</td><td>STRBPU</td><td>-</td></tr>
     <tr><td>01111101</td><td>LDRBPU</td><td>-</td><td>LDRBPU</td><td>-</td><td>LDRBPU</td><td>-</td><td>LDRBPU</td><td>-</td><td>LDRBPU</td><td>-</td><td>LDRBPU</td><td>-</td><td>LDRBPU</td><td>-</td><td>LDRBPU</td><td>-</td></tr>
-    <tr><td>01111111</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td></tr>
+    <tr><td>01111110</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td><td>STRBPUW</td><td>-</td></tr>
     <tr><td>01111111</td><td>LDRBPUW</td><td>-</td><td>LDRBPUW</td><td>-</td><td>LDRBPUW</td><td>-</td><td>LDRBPUW</td><td>-</td><td>LDRBPUW</td><td>-</td><td>LDRBPUW</td><td>-</td><td>LDRBPUW</td><td>-</td><td>LDRBPUW</td><td>-</td></tr>
     <tr><td rowspan=32>20:27</td><td>10000000</td><td colspan=16>STMDA</td></tr>
     <tr><td>10000001</td><td colspan=16>LDMDA</td></tr>
-    <tr><td>10000011</td><td colspan=16>STMDAW</td></tr>
+    <tr><td>10000010</td><td colspan=16>STMDAW</td></tr>
     <tr><td>10000011</td><td colspan=16>LDMDAW</td></tr>
     <tr><td>10000100</td><td colspan=16>STMSDA</td></tr>
     <tr><td>10000101</td><td colspan=16>LDMSDA</td></tr>
-    <tr><td>10000111</td><td colspan=16>STMSDAW</td></tr>
+    <tr><td>10000110</td><td colspan=16>STMSDAW</td></tr>
     <tr><td>10000111</td><td colspan=16>LDMSDAW</td></tr>
     <tr><td>10001000</td><td colspan=16>STMIA</td></tr>
     <tr><td>10001001</td><td colspan=16>LDMIA</td></tr>
-    <tr><td>10001011</td><td colspan=16>STMIAW</td></tr>
+    <tr><td>10001010</td><td colspan=16>STMIAW</td></tr>
     <tr><td>10001011</td><td colspan=16>LDMIAW</td></tr>
     <tr><td>10001100</td><td colspan=16>STMSIA</td></tr>
     <tr><td>10001101</td><td colspan=16>LDMSIA</td></tr>
-    <tr><td>10001111</td><td colspan=16>STMSIAW</td></tr>
+    <tr><td>10001110</td><td colspan=16>STMSIAW</td></tr>
     <tr><td>10001111</td><td colspan=16>LDMSIAW</td></tr>
     <tr><td>10010000</td><td colspan=16>STMDB</td></tr>
     <tr><td>10010001</td><td colspan=16>LDMDB</td></tr>
-    <tr><td>10010011</td><td colspan=16>STMDBW</td></tr>
+    <tr><td>10010010</td><td colspan=16>STMDBW</td></tr>
     <tr><td>10010011</td><td colspan=16>LDMDBW</td></tr>
     <tr><td>10010100</td><td colspan=16>STMSDB</td></tr>
     <tr><td>10010101</td><td colspan=16>LDMSDB</td></tr>
-    <tr><td>10010111</td><td colspan=16>STMSDBW</td></tr>
+    <tr><td>10010110</td><td colspan=16>STMSDBW</td></tr>
     <tr><td>10010111</td><td colspan=16>LDMSDBW</td></tr>
     <tr><td>10011000</td><td colspan=16>STMIB</td></tr>
     <tr><td>10011001</td><td colspan=16>LDMIB</td></tr>
-    <tr><td>10011011</td><td colspan=16>STMIBW</td></tr>
+    <tr><td>10011010</td><td colspan=16>STMIBW</td></tr>
     <tr><td>10011011</td><td colspan=16>LDMIBW</td></tr>
     <tr><td>10011100</td><td colspan=16>STMSIB</td></tr>
     <tr><td>10011101</td><td colspan=16>LDMSIB</td></tr>
-    <tr><td>10011111</td><td colspan=16>STMSIBW</td></tr>
+    <tr><td>10011110</td><td colspan=16>STMSIBW</td></tr>
     <tr><td>10011111</td><td colspan=16>LDMSIBW</td></tr>
     <tr><td rowspan=2>20:27</td><td>1010----</td><td colspan=16>B</td></tr>
     <tr><td>1011----</td><td colspan=16>BL</td></tr>
     <tr><td rowspan=32>20:27</td><td>11000000</td><td colspan=16>STC</td></tr>
     <tr><td>11000001</td><td colspan=16>LDC</td></tr>
-    <tr><td>11000011</td><td colspan=16>STCW</td></tr>
+    <tr><td>11000010</td><td colspan=16>STCW</td></tr>
     <tr><td>11000011</td><td colspan=16>LDCW</td></tr>
     <tr><td>11000100</td><td colspan=16>STCN</td></tr>
     <tr><td>11000101</td><td colspan=16>LDCN</td></tr>
-    <tr><td>11000111</td><td colspan=16>STCNW</td></tr>
+    <tr><td>11000110</td><td colspan=16>STCNW</td></tr>
     <tr><td>11000111</td><td colspan=16>LDCNW</td></tr>
     <tr><td>11001000</td><td colspan=16>STCU</td></tr>
     <tr><td>11001001</td><td colspan=16>LDCU</td></tr>
-    <tr><td>11001011</td><td colspan=16>STCUW</td></tr>
+    <tr><td>11001010</td><td colspan=16>STCUW</td></tr>
     <tr><td>11001011</td><td colspan=16>LDCUW</td></tr>
     <tr><td>11001100</td><td colspan=16>STCUN</td></tr>
     <tr><td>11001101</td><td colspan=16>LDCUN</td></tr>
-    <tr><td>11001111</td><td colspan=16>STCUNW</td></tr>
+    <tr><td>11001110</td><td colspan=16>STCUNW</td></tr>
     <tr><td>11001111</td><td colspan=16>LDCUNW</td></tr>
     <tr><td>11010000</td><td colspan=16>STCP</td></tr>
     <tr><td>11010001</td><td colspan=16>LDCP</td></tr>
-    <tr><td>11010011</td><td colspan=16>STCPW</td></tr>
+    <tr><td>11010010</td><td colspan=16>STCPW</td></tr>
     <tr><td>11010011</td><td colspan=16>LDCPW</td></tr>
     <tr><td>11010100</td><td colspan=16>STCPUN</td></tr>
     <tr><td>11010101</td><td colspan=16>LDCPUN</td></tr>
-    <tr><td>11010111</td><td colspan=16>STCPUNW</td></tr>
+    <tr><td>11010110</td><td colspan=16>STCPUNW</td></tr>
     <tr><td>11010111</td><td colspan=16>LDCPUNW</td></tr>
     <tr><td>11011000</td><td colspan=16>STCPN</td></tr>
     <tr><td>11011001</td><td colspan=16>LDCPN</td></tr>
-    <tr><td>11011011</td><td colspan=16>STCPNW</td></tr>
+    <tr><td>11011010</td><td colspan=16>STCPNW</td></tr>
     <tr><td>11011011</td><td colspan=16>LDCPNW</td></tr>
     <tr><td>11011100</td><td colspan=16>STCPUN</td></tr>
     <tr><td>11011101</td><td colspan=16>LDCPUN</td></tr>
-    <tr><td>11011111</td><td colspan=16>STCPUNW</td></tr>
+    <tr><td>11011110</td><td colspan=16>STCPUNW</td></tr>
     <tr><td>11011111</td><td colspan=16>LDCPUNW</td></tr>
     <tr>
         <td rowspan=17>20:27</td>


### PR DESCRIPTION
Often bit 20 in the table is unchanged. resulting in instructions with identical bit ranges (20:27). Presumably, this was not meant to be the case. 

As an example, 
Before: 
![image](https://user-images.githubusercontent.com/22038970/147861901-18f40c18-abf0-4e5f-a04f-b5a8d7a04adc.png)

After: 
![image](https://user-images.githubusercontent.com/22038970/147861922-3a4fef2d-b214-41d0-8790-ab6690252b09.png)

